### PR TITLE
Make material icons working + the play_arrow change

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Upstar Music</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/artists/ArtistIndex.js
+++ b/src/components/artists/ArtistIndex.js
@@ -41,7 +41,7 @@ class ArtistIndex extends Component {
           </p>
         </div>
         <Link to={`artists/${artist._id}`} className="secondary-content">
-           <i className="material-icons">></i>
+            <i className="material-icons">play_arrow</i>
          </Link>
       </li>
     );


### PR DESCRIPTION
I've got a problem with the icons. I just put the link for the icons coming from the docs of material-icons.

I got a problem with the arrow icon too. Wasn't like the one in your video. I change the name for get the one of material-icons.

## Without the change
![screen shot 2017-01-04 at 8 24 00 am](https://cloud.githubusercontent.com/assets/15819498/21643612/48f252c4-d257-11e6-8f9e-19d5ee2a8a6a.png)

## With the change
![screen shot 2017-01-04 at 8 24 29 am](https://cloud.githubusercontent.com/assets/15819498/21643619/514e35b4-d257-11e6-8a64-46ccd83135ae.png)
